### PR TITLE
Update dart-sass dependency to sass

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
   },
   "homepage": "https://github.com/liam-mills/GoldSrc.css#readme",
   "dependencies": {
-    "dart-sass": "^1.25.0"
+    "sass": "^1.54.4"
   }
 }


### PR DESCRIPTION
Dart-sass is the old version of the latest package called 'sass'.
https://www.npmjs.com/package/dart-sass is deprecated.
https://www.npmjs.com/package/sass is the latest package.

Script syntax remains the same.