### PR TITLE
Change sass to dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/liam-mills/GoldSrc.css/issues"
   },
   "homepage": "https://github.com/liam-mills/GoldSrc.css#readme",
-  "dependencies": {
+  "devDependencies": {
     "sass": "^1.54.4"
   }
 }


### PR DESCRIPTION
Depending on how this ends up being distributed you don't want to accidentally bundle in sass to client-side.